### PR TITLE
[SC - foundry.toml]: Add the `optimizer` related parameters + `gas` related parameters -> [Result]: Successful to resolve the `"Stack too deep"` error⭕️ - when running the deployment script on BASE Mainnet

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -10,6 +10,13 @@ ffi = true
 solc_version = "0.8.28"
 evm_version = "paris"
 
+optimizer = true
+optimizer_runs = 200
+
+# Gas configuration
+gas_limit = 10000000
+gas_price = 2000000000
+
 
 [profile.remappings]
 # ds-test = "lib/forge-std/lib/ds-test/src/"


### PR DESCRIPTION
- [SC - foundry.toml]: Add the `optimizer` related parameters + `gas` related parameters -> [Result]: Successful to resolve the `"Stack too deep"` error⭕️ - when running the deployment script on BASE Mainnet